### PR TITLE
Optimize RHEL .repo file according to Fedora/EPEL best practices

### DIFF
--- a/admin/manual_core.rst
+++ b/admin/manual_core.rst
@@ -141,7 +141,7 @@ operating systems may use the same archive format (RPM, DEB, etc.), or
 the same repository metadata formats (such as rpm-md, apt). However,
 do not use a repository which does
 not *exactly match* your system. Do not use Debian packages for an Ubuntu system
-or vice-versa. Do not use openSUSE packages for a Fedora system or vice-versa.
+or vice-versa. Do not use openSUSE packages for a RHEL system or vice-versa.
 Do not even remotely think of converting between formats.
 
 zypp
@@ -195,14 +195,14 @@ would be ``/etc/yum.repos.d/grommunio.repo``, with contents:
 .. code-block:: ini
 
 	[grommunio]
+	name=grommunio for Enterprise Linux 9
+	baseurl=https://download.grommunio.com/community/EL9/
 	enabled=1
-	autorefresh=1
-	baseurl=https://download.grommunio.com/community/EL8
-	type=rpm-md
-	keeppackages=0
+	gpgcheck=1
+	gpgkey=https://download.grommunio.com/RPM-GPG-KEY-grommunio
 
-Import the GPG key likewise, then proceed to use dnf or yum commands to update
-at your leisure.
+Accept the GPG key during the first package installation or update when
+proceeding with dnf or yum commands.
 
 apt
 ~~~


### PR DESCRIPTION
- Remove `autorefresh=1` which doesn't exist according to `dnf.conf(1)`
- Update `baseurl=…` for Red Hat Enterprise Linux 9 and derivatives
- Remove `type=rpm-md` which is already the default as per `dnf.conf(1)`
- Remove `keeppackages=0` which doesn't exist according to `dnf.conf(1)`
- Set `gpgcheck=1` to enable GPG signature check on packages
- Set `gpgkey=…` to specify URL for GPG key files used for signing

See also:
- https://src.fedoraproject.org/rpms/epel-release/blob/epel9/f/epel.repo
- https://github.com/rpm-software-management/dnf/blob/master/doc/conf_ref.rst
- https://dnf.readthedocs.io/en/latest/conf_ref.html
- https://man7.org/linux/man-pages/man5/dnf.conf.5.html