### PR TITLE
Fix typo 'UNited States' → 'United States'

### DIFF
--- a/admin/legal_notice.rst
+++ b/admin/legal_notice.rst
@@ -73,7 +73,7 @@ Ubuntu and Canonical are registered trademarks of Canonical Ltd.
 UNIX is registered trademark of The Open Group in the United States and other
 countries.
 
-VMware ESXi and VMware are registered trademarks of VMware, Inc. in the UNited
+VMware ESXi and VMware are registered trademarks of VMware, Inc. in the United
 States and other countries.
 
 All other trademarks, trade names, service marks, and companies referenced

--- a/dev/legal_notice.rst
+++ b/dev/legal_notice.rst
@@ -73,7 +73,7 @@ Ubuntu and Canonical are registered trademarks of Canonical Ltd.
 UNIX is registered trademark of The Open Group in the United States and other
 countries.
 
-VMware ESXi and VMware are registered trademarks of VMware, Inc. in the UNited
+VMware ESXi and VMware are registered trademarks of VMware, Inc. in the United
 States and other countries.
 
 All other trademarks, trade names, service marks, and companies referenced

--- a/kb/legal_notice.rst
+++ b/kb/legal_notice.rst
@@ -73,7 +73,7 @@ Ubuntu and Canonical are registered trademarks of Canonical Ltd.
 UNIX is registered trademark of The Open Group in the United States and other
 countries.
 
-VMware ESXi and VMware are registered trademarks of VMware, Inc. in the UNited
+VMware ESXi and VMware are registered trademarks of VMware, Inc. in the United
 States and other countries.
 
 All other trademarks, trade names, service marks, and companies referenced

--- a/man/legal_notice.rst
+++ b/man/legal_notice.rst
@@ -73,7 +73,7 @@ Ubuntu and Canonical are registered trademarks of Canonical Ltd.
 UNIX is registered trademark of The Open Group in the United States and other
 countries.
 
-VMware ESXi and VMware are registered trademarks of VMware, Inc. in the UNited
+VMware ESXi and VMware are registered trademarks of VMware, Inc. in the United
 States and other countries.
 
 All other trademarks, trade names, service marks, and companies referenced

--- a/migration/legal_notice.rst
+++ b/migration/legal_notice.rst
@@ -73,7 +73,7 @@ Ubuntu and Canonical are registered trademarks of Canonical Ltd.
 UNIX is registered trademark of The Open Group in the United States and other
 countries.
 
-VMware ESXi and VMware are registered trademarks of VMware, Inc. in the UNited
+VMware ESXi and VMware are registered trademarks of VMware, Inc. in the United
 States and other countries.
 
 All other trademarks, trade names, service marks, and companies referenced

--- a/resources/_templates/legal_notice.rst
+++ b/resources/_templates/legal_notice.rst
@@ -44,7 +44,7 @@ Ubuntu and Canonical are registered trademarks of Canonical Ltd.
 
 UNIX is registered trademark of The Open Group in the United States and other countries.
 
-VMware ESXi and VMware are registered trademarks of VMware, Inc. in the UNited States and other countries.
+VMware ESXi and VMware are registered trademarks of VMware, Inc. in the United States and other countries.
 
 All other trademarks, trade names, service marks, and companies referenced herein belong to their respective companies, foundations, or development communities.
 

--- a/user/legal_notice.rst
+++ b/user/legal_notice.rst
@@ -73,7 +73,7 @@ Ubuntu and Canonical are registered trademarks of Canonical Ltd.
 UNIX is registered trademark of The Open Group in the United States and other
 countries.
 
-VMware ESXi and VMware are registered trademarks of VMware, Inc. in the UNited
+VMware ESXi and VMware are registered trademarks of VMware, Inc. in the United
 States and other countries.
 
 All other trademarks, trade names, service marks, and companies referenced

--- a/web/legal_notice.rst
+++ b/web/legal_notice.rst
@@ -73,7 +73,7 @@ Ubuntu and Canonical are registered trademarks of Canonical Ltd.
 UNIX is registered trademark of The Open Group in the United States and other
 countries.
 
-VMware ESXi and VMware are registered trademarks of VMware, Inc. in the UNited
+VMware ESXi and VMware are registered trademarks of VMware, Inc. in the United
 States and other countries.
 
 All other trademarks, trade names, service marks, and companies referenced


### PR DESCRIPTION
As e.g. per [Wiktionary](https://en.wiktionary.org/wiki/United_States), 'United States' should be the correct spelling.