### PR TITLE
Document how to enable CRB and EPEL repositories on RHEL

### DIFF
--- a/admin/manual_core.rst
+++ b/admin/manual_core.rst
@@ -205,8 +205,14 @@ Accept the GPG key during the first package installation or update when
 proceeding with dnf or yum commands.
 
 .. note::
-        Our packages depend on packages in the EPEL repo. See https://docs.fedoraproject.org/en-US/epel/
-        for installation instructions.
+        Our packages depend on packages in the `CodeReady Linux Builder`_ and
+        the `EPEL`_ repository. To enable them, run ``dnf install epel-release``
+        followed by ``crb enable``.
+
+.. _CodeReady Linux Builder: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/package_manifest/index#CodeReadyLinuxBuilder-repository
+
+.. _EPEL: https://docs.fedoraproject.org/en-US/epel/
+
         
 apt
 ~~~


### PR DESCRIPTION
`gromox-2.3.56.5fff54d-39.1.x86_64.rpm` for RHEL 9 depends e.g. on:

- `libgumbo.so.1()(64bit)` → EPEL
- `libmysqlclient.so.21()(64bit)` → CRB
- `libtinyxml2.so.9()(64bit)` → EPEL
- `jsoncpp` → EPEL
- `w3m` → EPEL

Aside of this, EPEL packages may depend themself on packages in CRB, too. See also: https://docs.fedoraproject.org/en-US/epel/epel-policy/#_policy