### PR TITLE
Enhance Postfix configuration for common scenarios

### DIFF
--- a/admin/manual_core.rst
+++ b/admin/manual_core.rst
@@ -1166,7 +1166,7 @@ Set up a few Postfix directives:
 
 	postconf -e virtual_mailbox_domains=mysql:/etc/postfix/grommunio-virtual-mailbox-domains.cf
 	postconf -e virtual_mailbox_maps=mysql:/etc/postfix/grommunio-virtual-mailbox-maps.cf
-	postconf -e virtual_alias_maps=mysql:/etc/postfix/grommunio-virtual-alias-maps.cf
+	postconf -e virtual_alias_maps=mysql:/etc/postfix/grommunio-virtual-alias-maps.cf,mysql:/etc/postfix/grommunio-virtual-mailbox-maps.cf
 	postconf -e virtual_transport="smtp:[localhost]:24"
 
 Filenames for these additional configuration fragments,


### PR DESCRIPTION
As of writing the suggested Postfix configuration is incomplete, even for IMHO common SMTP scenarios. To make the documentation more helpful for manual setups, I added `virtual_mailbox_maps` with a slightly adapted configuration to also suitable for `smtpd_sender_login_maps` for SMTP submission.