### PR TITLE
operations: requeue snippet - don't override by mistake

### DIFF
--- a/admin/operations.rst
+++ b/admin/operations.rst
@@ -377,6 +377,7 @@ snippet:
    cd /var/lib/gromox/queue/
    j=0
    for i in save/*; do
+           [ -f "$i" ] || continue
            mv "$i" "mess/0$j"
            j=$(($j+1))
            echo "requeued $i"


### PR DESCRIPTION
refs:
https://github.com/crpb/grommunio/blob/e2711fde620763b59c00b40080bf04bf49e2a92d/enhancements/gromox-requeue/gromox-requeue https://gitlab.alpinelinux.org/alpine/aports/-/blob/26aea4af2a051866daa434ecade239a6cb7615eb/community/grommunio-gromox/gromox-requeue.cron