### PR TITLE
admin/operations: fix and improve requeueing

### DIFF
--- a/admin/operations.rst
+++ b/admin/operations.rst
@@ -348,7 +348,7 @@ command. For example, to move a specific message, use:
 
 .. code-block:: bash
 
-   mv <filename> /var/lib/gromox/queue/mess/
+   mv -vn <filename> /var/lib/gromox/queue/mess/
 
 Replace ``<filename>`` with the name of the message file you intend to requeue.
 If you wish to requeue multiple messages, you can use wildcards or specify
@@ -374,12 +374,13 @@ snippet:
 
 .. code-block:: sh
 
-   cd /var/lib/gromox/queue/
-   j=0
+   cd /var/lib/gromox/queue/ || exit 1
    for i in save/*; do
-           mv "$i" "mess/0$j"
-           j=$(($j+1))
-           echo "requeued $i"
+     test -e "$i" || continue
+     while [ -f mess/0 ]; do
+       sleep 1
+     done
+     mv -vn "$i" mess/0
    done
 
 


### PR DESCRIPTION
Using a filename which cannot be interpreted as integer value in decimal notation without any leading zeros does not work[1]. The **only** id which can be used save seems to be `0`, other values can be overwritten due to [2] and the implementation of `message_enqueue_retrieve_max_ID`[3] which is **not** free of race conditions. So better be save than sorry.

[1] https://github.com/grommunio/gromox/issues/135
[2] https://github.com/grommunio/gromox/pull/136
[3] https://github.com/grommunio/gromox/blob/17ca866e731a3c19a6e66491442dd68a72b0ad39/mda/message_enqueue.cpp#L328

The code has been improved:
- always use `mv -n` to **never** replace existing files
- do not croak if `save/` is empty